### PR TITLE
chore: add .claude/settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .DS_Store
 .playwright-mcp/
 *.tsbuildinfo
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore` to prevent session-specific tool permissions and local paths from being committed.

## Changes
- Add `.claude/settings.local.json` to `.gitignore`

## Why
The settings.local.json file contains:
- Session-specific tool permissions
- Machine-specific paths (e.g., `/home/robin/GIT/**`)
- Local configuration that shouldn't be shared

## Testing
- ✅ Verified file is now ignored by git
- ✅ No other files affected