### PR TITLE
fix: upgrade to Node.js 22 for npm Trusted Publishing support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify npm version
+        run: npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

npm Trusted Publishing was failing with 404 errors:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/f5cloudstatus-mcp-server
```

## Root Cause

**npm Trusted Publishing requires npm CLI v11.5.1 or later**

- Node.js 20 → npm 10.x ❌ (doesn't support OIDC)
- Node.js 22 → npm 11.x ✅ (supports OIDC)

## Solution

- ✅ Upgrade workflow from Node.js 20 → Node.js 22
- ✅ Add npm version verification step for debugging
- ✅ npm 11.x supports Trusted Publishing with OIDC

## Testing

This will be tested with the next release (v1.0.4).

Verified npm requirements:
- npm Trusted Publishing: Generally Available (July 2025)
- Minimum npm version: v11.5.1
- Node 22 ships with: npm 11.x ✅