### PR TITLE
chore: release v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f5cloudstatus-mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f5cloudstatus-mcp-server",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f5cloudstatus-mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server for F5 Cloud Status monitoring",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Release v1.0.4

Test automated npm publishing with Node.js 22 (npm 11.x).

### Changes
- Version bump: 1.0.3 → 1.0.4
- Node.js 22 for npm Trusted Publishing support

### Testing
This release tests OIDC publishing with npm 11.x.