### PR TITLE
fix: explicitly upgrade to npm 11 for Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm to v11 for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Verify npm version
         run: npm --version
 


### PR DESCRIPTION
## Problem
Node.js 22 in GitHub Actions ships with npm 10.9.3, which doesn't support npm Trusted Publishing (requires v11.5.1+).

## Solution  
Explicitly upgrade npm to latest (11.x) before publishing:
```yaml
- name: Upgrade npm to v11 for Trusted Publishing
  run: npm install -g npm@latest
```

This ensures we have npm 11+ which supports OIDC authentication.