### PR TITLE
chore: release v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f5cloudstatus-mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f5cloudstatus-mcp-server",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f5cloudstatus-mcp-server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "MCP server for F5 Cloud Status monitoring",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Release v1.0.5

Final test of npm Trusted Publishing with explicit npm 11 upgrade.

### Changes
- Version bump: 1.0.4 → 1.0.5
- Workflow now explicitly upgrades to npm 11.x