### PR TITLE
Rename repository and package to f5cloudstatus-mcp

### DIFF
--- a/.github/NPM_TRUSTED_PUBLISHING_SETUP.md
+++ b/.github/NPM_TRUSTED_PUBLISHING_SETUP.md
@@ -22,7 +22,7 @@ This guide explains how to set up npm Trusted Publishing with OpenID Connect (OI
 ### Step 1: Configure npm Trusted Publisher
 
 1. **Go to your package settings on npm:**
-   - Visit: https://www.npmjs.com/package/f5cloudstatus-mcp-server/access
+   - Visit: https://www.npmjs.com/package/f5cloudstatus-mcp/access
    - Or navigate to: Package → Settings → Publishing Access
 
 2. **Add a Trusted Publisher:**
@@ -32,7 +32,7 @@ This guide explains how to set up npm Trusted Publishing with OpenID Connect (OI
 
    ```
    Organization/User: robinmordasiewicz
-   Repository: f5cloudstatus-mcp-server
+   Repository: f5cloudstatus-mcp
    Workflow filename: publish.yml
    Environment name: npm-production (optional but recommended)
    ```
@@ -90,7 +90,7 @@ environment: npm-production  # Must match npm configuration
 
 3. **Verify provenance:**
    ```bash
-   npm audit signatures --package-lock-only f5cloudstatus-mcp-server
+   npm audit signatures --package-lock-only f5cloudstatus-mcp
    ```
 
 ## Workflow Configuration
@@ -196,11 +196,11 @@ Users can verify your package provenance:
 
 ```bash
 # Install and verify
-npm install f5cloudstatus-mcp-server
+npm install f5cloudstatus-mcp
 npm audit signatures
 
 # Or verify specific version
-npm audit signatures f5cloudstatus-mcp-server@1.0.1
+npm audit signatures f5cloudstatus-mcp@1.0.1
 ```
 
 This shows:
@@ -224,7 +224,7 @@ git push && git push --tags
 gh release create v1.0.x --generate-notes
 
 # Verify published package
-npm audit signatures f5cloudstatus-mcp-server
+npm audit signatures f5cloudstatus-mcp
 ```
 
 ---

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish to npm with Trusted Publishing (OIDC)
 
 # This workflow uses npm Trusted Publishing with OIDC (Generally Available as of July 2025)
-# No npm tokens required! Configure at: https://www.npmjs.com/package/f5cloudstatus-mcp-server/access
+# No npm tokens required! Configure at: https://www.npmjs.com/package/f5cloudstatus-mcp/access
 
 on:
   release:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "f5-status": {
+    "f5cloudstatus": {
       "command": "node",
       "args": [
         "dist/index.js"

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,2 +1,2 @@
-project_name: www.f5cloudstatus.com
+project_name: f5cloudstatus-mcp
 language: typescript

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -517,7 +517,7 @@ export class ToolHandler {
 ## Directory Structure
 
 ```
-f5cloudstatus-mcp-server/
+f5cloudstatus-mcp/
 ├── src/
 │   ├── server/
 │   │   ├── index.ts                 # Server entry point
@@ -1065,7 +1065,7 @@ User's Machine
     "f5-cloud-status": {
       "command": "node",
       "args": [
-        "/path/to/f5cloudstatus-mcp-server/dist/index.js"
+        "/path/to/f5cloudstatus-mcp/dist/index.js"
       ],
       "env": {
         "LOG_LEVEL": "info"

--- a/IMPLEMENTATION_WORKFLOW.md
+++ b/IMPLEMENTATION_WORKFLOW.md
@@ -44,8 +44,8 @@ Set up project infrastructure and core dependencies
 
 ```bash
 # Create project directory
-mkdir f5cloudstatus-mcp-server
-cd f5cloudstatus-mcp-server
+mkdir f5cloudstatus-mcp
+cd f5cloudstatus-mcp
 
 # Initialize npm project
 npm init -y

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,7 @@ The standard configuration for all MCP clients:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "npx",
-      "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+      "args": ["-y", "f5cloudstatus-mcp@latest"]
     }
   }
 }
@@ -47,7 +47,7 @@ This uses `npx` to automatically download and run the latest version. No manual 
 
 **CLI installation:**
 ```bash
-claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
+claude mcp add f5-cloud-status npx f5cloudstatus-mcp@latest
 ```
 
 **Or** use auto-discovery from Claude Desktop config (if `chat.mcp.discovery.enabled` is `true`).
@@ -58,7 +58,7 @@ claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
 
 **CLI installation:**
 ```bash
-code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp-server@latest"]}'
+code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp@latest"]}'
 ```
 
 **Or enable auto-discovery:**
@@ -74,7 +74,7 @@ code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus
   "chat.mcp.servers": {
     "f5-cloud-status": {
       "command": "npx",
-      "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+      "args": ["-y", "f5cloudstatus-mcp@latest"]
     }
   }
 }
@@ -109,7 +109,7 @@ code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus
      "cline.mcpServers": {
        "f5-cloud-status": {
          "command": "npx",
-         "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+         "args": ["-y", "f5cloudstatus-mcp@latest"]
        }
      }
    }
@@ -123,7 +123,7 @@ See [Cline MCP docs](https://docs.cline.bot/mcp/configuring-mcp-servers) for mor
 ### Global NPM Installation
 
 ```bash
-npm install -g f5cloudstatus-mcp-server
+npm install -g f5cloudstatus-mcp
 ```
 
 Configuration:
@@ -142,8 +142,8 @@ Configuration:
 For contributors and developers modifying the source:
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server.git
-cd f5cloudstatus-mcp-server
+git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp.git
+cd f5cloudstatus-mcp
 npm install
 npm run build
 ```
@@ -154,7 +154,7 @@ Configuration with absolute path:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "node",
-      "args": ["/absolute/path/to/f5cloudstatus-mcp-server/dist/index.js"]
+      "args": ["/absolute/path/to/f5cloudstatus-mcp/dist/index.js"]
     }
   }
 }
@@ -191,12 +191,12 @@ Required: Node.js 18.0.0 or later
 
 **Verify Package Installation:**
 ```bash
-npm list -g f5cloudstatus-mcp-server
+npm list -g f5cloudstatus-mcp
 ```
 
 **Test Server Standalone:**
 ```bash
-npx f5cloudstatus-mcp-server
+npx f5cloudstatus-mcp
 # Should output: "MCP Server started and listening on stdio"
 ```
 
@@ -254,8 +254,8 @@ curl https://www.f5cloudstatus.com/api/v2/summary.json
 
 ## Getting Help
 
-- **GitHub Issues**: https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server/issues
-- **NPM Package**: https://www.npmjs.com/package/f5cloudstatus-mcp-server
+- **GitHub Issues**: https://github.com/robinmordasiewicz/f5cloudstatus-mcp/issues
+- **NPM Package**: https://www.npmjs.com/package/f5cloudstatus-mcp
 - **Documentation**: See [README.md](README.md) for usage examples
 
 ## Verifying Installation

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -18,7 +18,7 @@ This works for **all MCP clients**:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "npx",
-      "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+      "args": ["-y", "f5cloudstatus-mcp@latest"]
     }
   }
 }
@@ -38,13 +38,13 @@ This works for **all MCP clients**:
 ### For Claude Code
 
 ```bash
-claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
+claude mcp add f5-cloud-status npx f5cloudstatus-mcp@latest
 ```
 
 ### For VS Code (with GitHub Copilot)
 
 ```bash
-code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp-server@latest"]}'
+code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp@latest"]}'
 ```
 
 Or enable auto-discovery: Set `"chat.mcp.discovery.enabled": true` in settings.
@@ -65,7 +65,7 @@ If you prefer a global installation:
 
 ```bash
 # Install globally
-npm install -g f5cloudstatus-mcp-server
+npm install -g f5cloudstatus-mcp
 ```
 
 Then configure:
@@ -87,8 +87,8 @@ Then configure:
 ### 1. Clone and Build
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server.git
-cd f5cloudstatus-mcp-server
+git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp.git
+cd f5cloudstatus-mcp
 npm install
 npm run build
 ```
@@ -116,7 +116,7 @@ Edit your MCP client configuration with the absolute path to `dist/index.js`:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "node",
-      "args": ["/absolute/path/to/f5cloudstatus-mcp-server/dist/index.js"]
+      "args": ["/absolute/path/to/f5cloudstatus-mcp/dist/index.js"]
     }
   }
 }
@@ -128,7 +128,7 @@ Edit your MCP client configuration with the absolute path to `dist/index.js`:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "C:\\Program Files\\nodejs\\node.exe",
-      "args": ["C:\\path\\to\\f5cloudstatus-mcp-server\\dist\\index.js"]
+      "args": ["C:\\path\\to\\f5cloudstatus-mcp\\dist\\index.js"]
     }
   }
 }
@@ -162,7 +162,7 @@ Ask your AI assistant any of these questions:
 **Using npx method:**
 ```bash
 # Test if npx works
-npx f5cloudstatus-mcp-server
+npx f5cloudstatus-mcp
 # Should show: "MCP Server started and listening on stdio"
 ```
 
@@ -245,6 +245,6 @@ See the [README.md](README.md) for complete development documentation.
 
 ## Getting Help
 
-- **GitHub Issues**: https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server/issues
-- **NPM Package**: https://www.npmjs.com/package/f5cloudstatus-mcp-server
+- **GitHub Issues**: https://github.com/robinmordasiewicz/f5cloudstatus-mcp/issues
+- **NPM Package**: https://www.npmjs.com/package/f5cloudstatus-mcp
 - **Troubleshooting**: See [INSTALLATION.md](INSTALLATION.md) for detailed troubleshooting

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Model Context Protocol (MCP) server for monitoring F5 Cloud service status, pr
   "mcpServers": {
     "f5-cloud-status": {
       "command": "npx",
-      "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+      "args": ["-y", "f5cloudstatus-mcp@latest"]
     }
   }
 }
@@ -37,7 +37,7 @@ A Model Context Protocol (MCP) server for monitoring F5 Cloud service status, pr
 
 **Command-line install** for Claude Code:
 ```bash
-claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
+claude mcp add f5-cloud-status npx f5cloudstatus-mcp@latest
 ```
 
 📦 **See [MCP Client Configuration](#mcp-client-configuration)** below for client-specific setup instructions.
@@ -45,8 +45,8 @@ claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
 ### Developer Setup
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server.git
-cd f5cloudstatus-mcp-server
+git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp.git
+cd f5cloudstatus-mcp
 npm install
 npm run build
 ```
@@ -100,7 +100,7 @@ The standard configuration for adding the F5 Cloud Status MCP server:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "npx",
-      "args": ["-y", "f5cloudstatus-mcp-server@latest"]
+      "args": ["-y", "f5cloudstatus-mcp@latest"]
     }
   }
 }
@@ -110,7 +110,7 @@ The standard configuration for adding the F5 Cloud Status MCP server:
 
 #### Claude Code
 ```bash
-claude mcp add f5-cloud-status npx f5cloudstatus-mcp-server@latest
+claude mcp add f5-cloud-status npx f5cloudstatus-mcp@latest
 ```
 
 #### Claude Desktop
@@ -128,7 +128,7 @@ Use the base configuration in Cline's MCP settings. See [Cline MCP docs](https:/
 
 #### VS Code / GitHub Copilot
 ```bash
-code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp-server@latest"]}'
+code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["f5cloudstatus-mcp@latest"]}'
 ```
 
 Or enable auto-discovery in VS Code settings:
@@ -146,7 +146,7 @@ Or enable auto-discovery in VS Code settings:
 
 #### Global NPM Installation
 ```bash
-npm install -g f5cloudstatus-mcp-server
+npm install -g f5cloudstatus-mcp
 ```
 
 Configuration:
@@ -164,8 +164,8 @@ Configuration:
 For contributors and developers modifying the source:
 
 ```bash
-git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server.git
-cd f5cloudstatus-mcp-server
+git clone https://github.com/robinmordasiewicz/f5cloudstatus-mcp.git
+cd f5cloudstatus-mcp
 npm install && npm run build
 ```
 
@@ -175,7 +175,7 @@ Configuration:
   "mcpServers": {
     "f5-cloud-status": {
       "command": "node",
-      "args": ["/absolute/path/to/f5cloudstatus-mcp-server/dist/index.js"]
+      "args": ["/absolute/path/to/f5cloudstatus-mcp/dist/index.js"]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "f5cloudstatus-mcp-server",
+  "name": "f5cloudstatus-mcp",
   "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "f5cloudstatus-mcp-server",
+      "name": "f5cloudstatus-mcp",
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "f5cloudstatus-mcp-server",
+  "name": "f5cloudstatus-mcp",
   "version": "1.0.5",
   "description": "MCP server for F5 Cloud Status monitoring",
   "main": "dist/index.js",
@@ -36,11 +36,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server.git"
+    "url": "git+https://github.com/robinmordasiewicz/f5cloudstatus-mcp.git"
   },
-  "homepage": "https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server#readme",
+  "homepage": "https://github.com/robinmordasiewicz/f5cloudstatus-mcp#readme",
   "bugs": {
-    "url": "https://github.com/robinmordasiewicz/f5cloudstatus-mcp-server/issues"
+    "url": "https://github.com/robinmordasiewicz/f5cloudstatus-mcp/issues"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -35,7 +35,7 @@ export class MCPServer {
     // Initialize server
     this.server = new Server(
       {
-        name: 'f5cloudstatus-mcp-server',
+        name: 'f5cloudstatus-mcp',
         version: '1.0.0',
       },
       {


### PR DESCRIPTION
## Summary
Complete repository and package renaming from `f5cloudstatus-mcp-server` to `f5cloudstatus-mcp`

### Changes Made
- ✅ Renamed GitHub repository to `f5cloudstatus-mcp`
- ✅ Force unpublished old npm package `f5cloudstatus-mcp-server`
- ✅ Updated package.json name and all repository URLs
- ✅ Updated package-lock.json references
- ✅ Updated MCP server name in src/server/mcp-server.ts
- ✅ Updated all documentation files:
  - README.md (11 package references + 3 GitHub URLs)
  - INSTALLATION.md (10 package references + 3 GitHub URLs)
  - QUICKSTART.md (6 package references + 3 GitHub URLs)
  - IMPLEMENTATION_WORKFLOW.md (2 directory references)
  - ARCHITECTURE.md (1 directory reference)
- ✅ Updated .github/workflows/publish.yml (1 npm URL)
- ✅ Updated .github/NPM_TRUSTED_PUBLISHING_SETUP.md (6 package references)
- ✅ Updated .serena/project.yml project name
- ✅ Second pass verification: All references confirmed updated

### Files Modified
- `.github/NPM_TRUSTED_PUBLISHING_SETUP.md`
- `.github/workflows/publish.yml`
- `.mcp.json`
- `.serena/project.yml`
- `ARCHITECTURE.md`
- `IMPLEMENTATION_WORKFLOW.md`
- `INSTALLATION.md`
- `QUICKSTART.md`
- `README.md`
- `package-lock.json`
- `package.json`
- `src/server/mcp-server.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)