### PR TITLE
fix: update MCP server name to f5xc-cloudstatus

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -146,7 +146,7 @@ jobs:
           \`\`\`json
           {
             "mcpServers": {
-              "f5-cloud-status": {
+              "f5xc-cloudstatus": {
                 "command": "npx",
                 "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@${{ steps.version.outputs.version }}"]
               }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The standard configuration for all MCP clients:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "npx",
       "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
     }
@@ -42,13 +42,13 @@ This uses `npx` to automatically download and run the latest version. No manual 
 
 3. **Restart Claude Desktop**
 
-4. **Verify**: Look for the 🔌 MCP icon showing "f5-cloud-status" connected
+4. **Verify**: Look for the 🔌 MCP icon showing "f5xc-cloudstatus" connected
 
 ### Claude Code
 
 **CLI installation:**
 ```bash
-claude mcp add f5-cloud-status npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
+claude mcp add f5xc-cloudstatus npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
 ```
 
 ### VS Code (with GitHub Copilot)
@@ -57,7 +57,7 @@ claude mcp add f5-cloud-status npx @robinmordasiewicz/f5xc-cloudstatus-mcp@lates
 
 **CLI installation:**
 ```bash
-code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]}'
+code --add-mcp '{"name":"f5xc-cloudstatus","command":"npx","args":["@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]}'
 ```
 
 **Or enable auto-discovery:**
@@ -71,7 +71,7 @@ code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["@robinmordasi
 ```json
 {
   "chat.mcp.servers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "npx",
       "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
     }
@@ -106,7 +106,7 @@ code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["@robinmordasi
    ```json
    {
      "cline.mcpServers": {
-       "f5-cloud-status": {
+       "f5xc-cloudstatus": {
          "command": "npx",
          "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
        }
@@ -127,7 +127,7 @@ Configuration:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "f5xc-cloudstatus-mcp"
     }
   }

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -334,7 +334,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 const server = new Server({
-  name: "f5-cloud-status",
+  name: "f5xc-cloudstatus",
   version: "1.0.0"
 }, {
   capabilities: {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -756,7 +756,7 @@ export interface Config {
 
 export const defaultConfig: Config = {
   server: {
-    name: "f5-cloud-status",
+    name: "f5xc-cloudstatus",
     version: "1.0.0"
   },
   api: {
@@ -1062,7 +1062,7 @@ User's Machine
 // Claude Desktop config.json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "node",
       "args": [
         "/path/to/f5xc-cloudstatus-mcp/dist/index.js"

--- a/docs/IMPLEMENTATION_WORKFLOW.md
+++ b/docs/IMPLEMENTATION_WORKFLOW.md
@@ -350,7 +350,7 @@ export interface Config {
 
 export const defaultConfig: Config = {
   server: {
-    name: "f5-cloud-status",
+    name: "f5xc-cloudstatus",
     version: "1.0.0"
   },
   api: {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -16,7 +16,7 @@ This works for **all MCP clients**:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "npx",
       "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
     }
@@ -33,18 +33,18 @@ This works for **all MCP clients**:
 
 2. Add base configuration (above)
 3. Restart Claude Desktop
-4. Look for 🔌 MCP icon → "f5-cloud-status" connected
+4. Look for 🔌 MCP icon → "f5xc-cloudstatus" connected
 
 ### For Claude Code
 
 ```bash
-claude mcp add f5-cloud-status npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
+claude mcp add f5xc-cloudstatus npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
 ```
 
 ### For VS Code (with GitHub Copilot)
 
 ```bash
-code --add-mcp '{"name":"f5-cloud-status","command":"npx","args":["@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]}'
+code --add-mcp '{"name":"f5xc-cloudstatus","command":"npx","args":["@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]}'
 ```
 
 Or enable auto-discovery: Set `"chat.mcp.discovery.enabled": true` in settings.
@@ -73,7 +73,7 @@ Then configure:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "f5xc-cloudstatus-mcp"
     }
   }
@@ -114,7 +114,7 @@ Edit your MCP client configuration with the absolute path to `dist/index.js`:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "node",
       "args": ["/absolute/path/to/f5xc-cloudstatus-mcp/dist/index.js"]
     }
@@ -126,7 +126,7 @@ Edit your MCP client configuration with the absolute path to `dist/index.js`:
 ```json
 {
   "mcpServers": {
-    "f5-cloud-status": {
+    "f5xc-cloudstatus": {
       "command": "C:\\Program Files\\nodejs\\node.exe",
       "args": ["C:\\path\\to\\f5xc-cloudstatus-mcp\\dist\\index.js"]
     }


### PR DESCRIPTION
## Summary
Update MCP server name from `f5-cloud-status` to `f5xc-cloudstatus` for consistency with package naming conventions.

## Changes
- ✅ Update all configuration examples to use `"f5xc-cloudstatus"`
- ✅ Update README.md installation instructions
- ✅ Update docs/QUICKSTART.md configuration examples
- ✅ Update GitHub workflow templates
- ✅ Update documentation references

## Configuration Example
**Before:**
```json
{
  "mcpServers": {
    "f5-cloud-status": {
      "command": "npx",
      "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
    }
  }
}
```

**After:**
```json
{
  "mcpServers": {
    "f5xc-cloudstatus": {
      "command": "npx",
      "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
    }
  }
}
```

## CLI Commands
**Before:**
```bash
claude mcp add f5-cloud-status npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
```

**After:**
```bash
claude mcp add f5xc-cloudstatus npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest
```

## Impact
Users will need to update their MCP server name in their configuration files from `f5-cloud-status` to `f5xc-cloudstatus`. This ensures naming consistency throughout the project.

## Files Modified
- .github/workflows/auto-publish.yml
- README.md
- docs/ANALYSIS.md
- docs/ARCHITECTURE.md
- docs/IMPLEMENTATION_WORKFLOW.md
- docs/QUICKSTART.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)