### PR TITLE
fix: sanitize package name for MCPB filename

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -110,9 +110,11 @@ jobs:
         run: |
           VERSION="${{ steps.version_bump.outputs.version }}"
           PACKAGE_NAME=$(jq -r '.name' manifest.json)
+          # Sanitize package name for filename (remove @ and replace / with -)
+          SAFE_PACKAGE_NAME=$(echo "$PACKAGE_NAME" | sed 's/@//g' | sed 's/\//-/g')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
-          echo "filename=${PACKAGE_NAME}-${VERSION}.mcpb" >> $GITHUB_OUTPUT
+          echo "filename=${SAFE_PACKAGE_NAME}-${VERSION}.mcpb" >> $GITHUB_OUTPUT
 
       - name: Rename MCPB file
         run: |


### PR DESCRIPTION
## Summary
Fix GitHub Actions workflow failure when creating MCPB files with scoped package names.

## Problem
The workflow was failing with:
```
mv: cannot move './f5xc-cloudstatus-mcp.mcpb' to '@robinmordasiewicz/f5xc-cloudstatus-mcp-1.2.4.mcpb': No such file or directory
```

The `@` and `/` characters in scoped package names (`@robinmordasiewicz/f5xc-cloudstatus-mcp`) are invalid in filenames:
- `@` at the start can cause issues with some shells
- `/` is interpreted as a directory separator

## Solution
Sanitize the package name before using it in the filename:
- Remove `@` character
- Replace `/` with `-`

**Before:** `@robinmordasiewicz/f5xc-cloudstatus-mcp-1.2.4.mcpb` ❌
**After:** `robinmordasiewicz-f5xc-cloudstatus-mcp-1.2.4.mcpb` ✅

## Changes
```bash
# Added sanitization step
SAFE_PACKAGE_NAME=$(echo "$PACKAGE_NAME" | sed 's/@//g' | sed 's/\//-/g')
echo "filename=${SAFE_PACKAGE_NAME}-${VERSION}.mcpb" >> $GITHUB_OUTPUT
```

## Impact
- Fixes auto-publish workflow for scoped packages
- MCPB files will now be named correctly and upload successfully
- No changes to package functionality or installation

## Testing
This fix will be tested when the workflow runs on merge. The MCPB file should:
1. ✅ Be renamed successfully without errors
2. ✅ Upload as a release asset
3. ✅ Have a valid filename format

## Related
- Fixes workflow failure: https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp/actions/runs/20866509252

🤖 Generated with [Claude Code](https://claude.com/claude-code)