### PR TITLE
Fix MkDocs workflow pip caching

### DIFF
--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -30,12 +30,10 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
+          cache-dependency-path: 'requirements-docs.txt'
 
       - name: Install dependencies
-        run: |
-          pip install mkdocs-material>=9.7.0
-          pip install mkdocs-minify-plugin>=0.8.0
-          pip install pymdown-extensions>=10.14
+        run: pip install -r requirements-docs.txt
 
       - name: Build MkDocs site
         run: mkdocs build --strict


### PR DESCRIPTION
## Problem

The MkDocs deployment workflow was failing with this error:
```
No file in /home/runner/work/f5xc-cloudstatus-mcp/f5xc-cloudstatus-mcp matched to [**/requirements.txt or **/pyproject.toml]
```

The `setup-python@v5` action with `cache: pip` expects to find either `requirements.txt` or `pyproject.toml`, but we're using `requirements-docs.txt`.

## Solution

- Added `cache-dependency-path: 'requirements-docs.txt'` to specify the correct requirements file path
- Simplified the install step to use `pip install -r requirements-docs.txt` instead of individual package installations

## Benefits

✅ Fixes workflow failure  
✅ Enables proper pip dependency caching  
✅ Cleaner, more maintainable install step  

## Testing

This change will allow the workflow to:
1. Cache pip dependencies correctly
2. Complete the MkDocs build successfully
3. Deploy to gh-pages branch

Fixes: https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp/actions/runs/20867954471


🤖 Generated with [Claude Code](https://claude.com/claude-code)