### PR TITLE
docs: add Material for MkDocs site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,51 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,55 @@
+# F5 Cloud Status MCP Server
+
+MCP server for monitoring F5 Distributed Cloud service status, components, incidents, and maintenance.
+
+## Installation
+
+```json
+{
+  "mcpServers": {
+    "f5xc-cloudstatus": {
+      "command": "npx",
+      "args": ["-y", "@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]
+    }
+  }
+}
+```
+
+### Config file locations:
+
+- **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) | `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
+- **Claude Code**: `claude mcp add f5xc-cloudstatus npx @robinmordasiewicz/f5xc-cloudstatus-mcp@latest`
+- **VS Code**: `code --add-mcp '{"name":"f5xc-cloudstatus","command":"npx","args":["@robinmordasiewicz/f5xc-cloudstatus-mcp@latest"]}'`
+- **Cursor**: `.cursor/mcp.json`
+- **Windsurf**: Plugins → Search "F5 Cloud Status" → Install
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `f5-status-get-overall` | Current overall status |
+| `f5-status-get-components` | All service components with status |
+| `f5-status-get-component` | Specific component details |
+| `f5-status-get-incidents` | Current and recent incidents |
+| `f5-status-get-maintenance` | Scheduled maintenance windows |
+| `f5-status-search` | Search components, incidents, maintenance |
+
+## Example Queries
+
+```
+What is the current status of F5 Cloud services?
+Are there any active incidents?
+Show me components that are degraded
+What maintenance is scheduled?
+Search for API Gateway
+```
+
+## Links
+
+- [npm](https://www.npmjs.com/package/@robinmordasiewicz/f5xc-cloudstatus-mcp)
+- [GitHub](https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp)
+- [Issues](https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp/issues)
+
+## License
+
+MIT

--- a/docs/javascripts/sidebar-fix.js
+++ b/docs/javascripts/sidebar-fix.js
@@ -1,0 +1,13 @@
+// Fix for sidebar rendering issues with Material for MkDocs
+(function() {
+  'use strict';
+
+  // Ensure sidebar navigation is properly initialized
+  document.addEventListener('DOMContentLoaded', function() {
+    const sidebar = document.querySelector('.md-sidebar--primary');
+    if (sidebar) {
+      // Trigger any pending rendering
+      sidebar.offsetHeight;
+    }
+  });
+})();

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,205 @@
+/* F5 Cloud Status MCP Server Theme */
+
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #4f73ff;
+  --md-primary-fg-color--light: #6b8aff;
+  --md-primary-fg-color--dark: #3d5ee6;
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: #f3f4f9;
+  --md-accent-fg-color: #4f73ff;
+  --md-accent-fg-color--transparent: rgba(79, 115, 255, 0.1);
+  --md-accent-bg-color: #e5eaff;
+  --md-default-fg-color: #0f1e57;
+  --md-default-fg-color--light: #6c778c;
+  --md-default-fg-color--lighter: #a0a7c2;
+  --md-default-fg-color--lightest: #c9cfdf;
+  --md-default-bg-color: #ffffff;
+  --md-default-bg-color--light: #f3f4f9;
+  --md-default-bg-color--lighter: #f8f9fc;
+  --md-code-fg-color: #0f1e57;
+  --md-code-bg-color: #f3f4f9;
+  --md-code-hl-color: rgba(79, 115, 255, 0.1);
+  --md-typeset-color: #0f1e57;
+  --md-typeset-a-color: #4f73ff;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #0d1117;
+  --md-default-bg-color--light: #161b22;
+  --md-default-bg-color--lighter: #21262d;
+  --md-default-fg-color: #e6edf3;
+  --md-default-fg-color--light: #8b949e;
+  --md-default-fg-color--lighter: #6e7681;
+  --md-primary-fg-color: #58a6ff;
+  --md-primary-fg-color--light: #79c0ff;
+  --md-primary-fg-color--dark: #388bfd;
+  --md-accent-fg-color: #58a6ff;
+  --md-code-bg-color: #161b22;
+  --md-code-fg-color: #e6edf3;
+  --md-typeset-color: #e6edf3;
+  --md-typeset-a-color: #58a6ff;
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background-color: #010409;
+  box-shadow: 0 1px 0 #21262d;
+}
+
+[data-md-color-scheme="slate"] .md-tabs {
+  background-color: #010409;
+  border-bottom: 1px solid #21262d;
+}
+
+[data-md-color-scheme="slate"] .md-tabs__link {
+  color: #8b949e;
+}
+
+[data-md-color-scheme="slate"] .md-tabs__item--active .md-tabs__link,
+[data-md-color-scheme="slate"] .md-tabs__item--active .md-tabs__link:hover {
+  color: #58a6ff !important;
+  border-bottom: 2px solid #58a6ff !important;
+}
+
+html {
+  font-size: 16px;
+}
+
+.md-typeset {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.md-typeset h2 {
+  border-bottom: 1px solid #e6e9f3;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.375rem;
+}
+
+.md-typeset a {
+  color: var(--md-typeset-a-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.md-typeset a:hover {
+  text-decoration: underline;
+}
+
+.md-header {
+  background-color: var(--md-primary-bg-color);
+  box-shadow: 0 1px 0 #e6e9f3;
+}
+
+.md-search__input {
+  background-color: var(--md-default-bg-color--light);
+  color: var(--md-default-fg-color);
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.md-tabs {
+  background-color: var(--md-primary-bg-color);
+  border-bottom: 1px solid #e6e9f3;
+}
+
+.md-tabs__link {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.md-tabs__link:hover {
+  color: var(--md-primary-fg-color);
+}
+
+[data-md-color-scheme="default"] .md-tabs__item--active .md-tabs__link,
+[data-md-color-scheme="default"] .md-tabs__item--active .md-tabs__link:hover {
+  color: #2952cc !important;
+  border-bottom: 2px solid #2952cc !important;
+}
+
+.md-typeset table:not([class]) {
+  font-size: 0.8125rem;
+  border: 1px solid #e6e9f3;
+  border-radius: 0.375rem;
+  margin: 0.75rem 0;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-default-bg-color--light);
+  color: var(--md-default-fg-color);
+  font-weight: 600;
+  padding: 0.5rem 0.625rem;
+  border-bottom: 1px solid #e6e9f3;
+}
+
+.md-typeset table:not([class]) td {
+  padding: 0.375rem 0.625rem;
+  border-bottom: 1px solid #e6e9f3;
+}
+
+.md-typeset code {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.8em;
+  background-color: var(--md-code-bg-color);
+  color: var(--md-code-fg-color);
+  border-radius: 0.1875rem;
+  padding: 0.0625rem 0.25rem;
+}
+
+.md-typeset pre {
+  background-color: var(--md-code-bg-color);
+  border-radius: 0.375rem;
+  border: 1px solid #e6e9f3;
+  margin: 0.75rem 0;
+}
+
+.md-typeset pre > code {
+  font-size: 0.75rem;
+  line-height: 1.5;
+  padding: 0.625rem 0.75rem;
+}
+
+.md-typeset .admonition,
+.md-typeset details {
+  border: 1px solid #e6e9f3;
+  border-radius: 0.375rem;
+  background-color: var(--md-default-bg-color);
+  margin: 0.75rem 0;
+}
+
+.md-typeset .admonition-title,
+.md-typeset details summary {
+  background-color: var(--md-default-bg-color--light);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  padding: 0.375rem 0.75rem;
+  border-bottom: 1px solid #e6e9f3;
+}
+
+.md-typeset hr {
+  border: none;
+  border-top: 1px solid #e6e9f3;
+  margin: 2rem 0;
+}
+
+.md-footer {
+  background-color: var(--md-default-bg-color--light);
+}
+
+.md-footer__link {
+  color: var(--md-default-fg-color);
+}
+
+.md-content__inner {
+  padding: 0.75rem 1rem;
+}
+
+@media screen and (min-width: 76.25em) {
+  .md-content__inner {
+    padding: 1rem 1.5rem;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,89 @@
+site_name: F5 Cloud Status MCP Server
+site_description: MCP server for F5 Distributed Cloud service status monitoring
+site_url: https://robinmordasiewicz.github.io/f5xc-cloudstatus-mcp/
+repo_name: robinmordasiewicz/f5xc-cloudstatus-mcp
+repo_url: https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp
+
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.indexes
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - navigation.instant
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - toc.follow
+    - header.autohide
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/console
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.mark
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - admonition
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+      toc_depth: 3
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp
+  generator: false
+
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/sidebar-fix.js
+
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary
- Add Material for MkDocs with custom F5 indigo theme
- Configure automatic GitHub Pages deployment to gh-pages branch
- Create documentation site structure with stylesheets matching reference repo

## Files Added
- mkdocs.yml - MkDocs configuration with Material theme
- docs/index.md - Home page with installation and tool reference
- docs/stylesheets/extra.css - F5 indigo color scheme and styling
- docs/overrides/main.html - Material theme base override
- docs/javascripts/sidebar-fix.js - Sidebar rendering utilities
- .github/workflows/deploy-docs.yml - GitHub Pages deployment workflow

## Theme
- Color scheme: F5 Indigo (primary: #4f73ff)
- Dark mode: GitHub Dark theme
- Features: Navigation tabs, search, code copy, toc tracking
- Fonts: Inter (text), JetBrains Mono (code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)