### PR TITLE
fix: explicitly configure git remote to use PAT_TOKEN for push authentication

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -38,6 +38,8 @@ jobs:
           if [ -n "${{ secrets.PAT_TOKEN }}" ]; then
             git config user.name "robinmordasiewicz"
             git config user.email "r.mordasiewicz@f5.com"
+            # Configure remote URL to use PAT for authentication
+            git remote set-url origin "https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Remaining Issue

Even after using PAT user identity for commits, pushes still fail:
```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request
```

## Root Cause

The `actions/checkout@v4` step configures the PAT_TOKEN, but when `git push` executes, it may not use the correct authentication context that GitHub recognizes as having bypass permissions.

## Solution

Explicitly configure the git remote URL to embed the PAT_TOKEN for HTTPS authentication:

```yaml
git remote set-url origin "https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git"
```

This ensures:
1. Push operation uses PAT_TOKEN for authentication
2. GitHub recognizes the push as coming from robinmordasiewicz (admin user)
3. Admin bypass permissions apply (actor_id 5, RepositoryRole in bypass_actors)
4. Push bypasses PR requirement successfully

## Testing

After merge, workflow will:
1. ✅ Configure git with PAT user identity
2. ✅ Set remote URL with PAT_TOKEN authentication
3. ✅ Push version bump as admin with bypass
4. ✅ Complete full publish cycle to npm + GitHub Packages