### PR TITLE
fix: explicitly set npm registry to npmjs.org for publishing

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -242,7 +242,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          # Ensure we're publishing to npmjs.org, not GitHub Packages
+          npm config set registry https://registry.npmjs.org/
+          npm publish --access public --registry https://registry.npmjs.org
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Issue  

After successfully bypassing branch protection and publishing to GitHub Packages, the npm publish step fails with:

```
npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@robinmordasiewicz%2ff5xc-cloudstatus-mcp
```

## Root Cause

Despite setting up Node.js with `registry-url: 'https://registry.npmjs.org'`, npm is attempting to publish to GitHub Packages registry. This happens because npm config retains settings from the previous "Publish to GitHub Packages" step.

## Solution

Explicitly configure npm registry before publishing:

```bash
npm config set registry https://registry.npmjs.org/
npm publish --access public --registry https://registry.npmjs.org
```

## Testing

After merge, the complete workflow will:
1. ✅ Auto-bump version and push to main  
2. ✅ Create git tag and GitHub release
3. ✅ Publish to GitHub Packages
4. ✅ **Publish to npmjs.org** (FIXED)

This completes the full automation cycle!