### PR TITLE
fix: ensure package.json is clean before npm publish

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -235,6 +235,15 @@ jobs:
             mv package.json.backup package.json
           fi
 
+      - name: Verify package.json (remove publishConfig if exists)
+        run: |
+          # Remove publishConfig to ensure clean state for npm publish
+          jq 'del(.publishConfig)' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          echo "📝 Verified package.json - publishConfig removed"
+          echo "Current registry config in package.json:"
+          jq '.publishConfig // "none"' package.json
+
       - name: Setup Node.js for npm
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
Added verification step to explicitly remove publishConfig from package.json before publishing to npmjs.org, preventing 401 authentication errors.

## Problem
The Auto Version and Publish workflow was failing with:
```
401 Unauthorized - PUT https://npm.pkg.github.com/@robinmordasiewicz%2ff5xc-cloudstatus-mcp
```

Even though explicit registry configuration was in place (`npm config set` + `--registry` flag), npm was still trying to publish to GitHub Packages.

## Root Cause
The workflow temporarily modifies package.json to add `publishConfig: {"registry": "https://npm.pkg.github.com"}` for GitHub Packages publishing. While there's a restore step, the publishConfig can persist in edge cases, causing npm to ignore the explicit registry flags.

## Solution
Added a verification step that explicitly removes any publishConfig from package.json using jq before the npm publish step.

## Changes
**.github/workflows/auto-publish.yml:**
- Added "Verify package.json (remove publishConfig if exists)" step (lines 238-245)
- Uses `jq 'del(.publishConfig)'` to ensure clean state
- Adds logging to confirm publishConfig removal
- Runs after restore, before Node.js setup for npm

## Impact
- ✅ package.json guaranteed clean before npm publish
- ✅ npm will respect explicit --registry flag
- ✅ No 401 errors from wrong registry attempts
- ✅ Workflow will complete successfully

## Testing
After merge, the workflow will trigger on next code change (non-.github path). Expected results:
1. Package builds successfully
2. Publishes to GitHub Packages ✓
3. package.json restored ✓
4. publishConfig verified removed (new step)
5. Publishes to npmjs.org ✓ (no 401 error)
6. GitHub release created ✓

## Notes
- This fix complements the existing explicit registry configuration
- Provides defense-in-depth against publishConfig persistence
- No impact on package functionality or existing builds

Fixes #49